### PR TITLE
Fix for next HDT update. Card.Rarity type was changed from string to enum.

### DIFF
--- a/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV02.cs
+++ b/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV02.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Hearthstone_Deck_Tracker.Enums;
 
 namespace Hearthstone_Collection_Tracker.Internal.DataUpdaters
 {
@@ -40,7 +41,7 @@ namespace Hearthstone_Collection_Tracker.Internal.DataUpdaters
                         var originalCard = cards.FirstOrDefault(c => c.Id == card.CardId);
                         if (originalCard != null)
                         {
-                            card.DesiredAmount = originalCard.Rarity == "Legendary" ? 1 : 2;
+                            card.DesiredAmount = originalCard.Rarity == Rarity.Legendary ? 1 : 2;
                         }
                     }
                 }
@@ -54,7 +55,7 @@ namespace Hearthstone_Collection_Tracker.Internal.DataUpdaters
                         AmountGolden = 0,
                         AmountNonGolden = 0,
                         CardId = c.Id,
-                        DesiredAmount = c.Rarity == "Legendary" ? 1 : 2
+                        DesiredAmount = c.Rarity == Rarity.Legendary ? 1 : 2
                     }).ToList()
                 });
                 Hearthstone_Deck_Tracker.XmlManager<List<BasicSetCollectionInfo>>.Save(newCollectionFilePath, oldSetInfo);

--- a/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV022.cs
+++ b/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV022.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Hearthstone_Deck_Tracker.Enums;
 
 namespace Hearthstone_Collection_Tracker.Internal.DataUpdaters
 {
@@ -76,7 +77,7 @@ namespace Hearthstone_Collection_Tracker.Internal.DataUpdaters
                 {
                     foreach(var card in set.Cards)
                     {
-                        if (gameCards.First(c => c.Id == card.CardId).Rarity != "Legendary")
+                        if (gameCards.First(c => c.Id == card.CardId).Rarity != Rarity.Legendary)
                             continue;
 
                         card.AmountGolden = Math.Min(card.AmountGolden, 1);

--- a/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
+++ b/Hearthstone Collection Tracker/ViewModels/CardInCollection.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Xml.Serialization;
+using Hearthstone_Deck_Tracker.Enums;
 
 namespace Hearthstone_Collection_Tracker.ViewModels
 {
@@ -53,7 +54,7 @@ namespace Hearthstone_Collection_Tracker.ViewModels
             {
                 if (Card == null)
                     throw new ArgumentNullException();
-                return Card.Rarity == "Legendary" ? 1 : 2;
+                return Card.Rarity == Rarity.Legendary ? 1 : 2;
             }
         }
 

--- a/Hearthstone Collection Tracker/ViewModels/SetDetailInfoViewModel.cs
+++ b/Hearthstone Collection Tracker/ViewModels/SetDetailInfoViewModel.cs
@@ -19,7 +19,7 @@ namespace Hearthstone_Collection_Tracker.ViewModels
                 if (args.PropertyName == "SetCards")
                 {
                     List<CardStatsByRarity> cardStats = SetCards.GroupBy(c => c.Card.Rarity, c => c)
-                        .Select(gr => new CardStatsByRarity(gr.Key, gr.AsEnumerable()))
+                        .Select(gr => new CardStatsByRarity(gr.Key.ToString(), gr.AsEnumerable()))
                         .ToList();
                     TotalSetStats = new CardStatsByRarity("Total", SetCards);
                     cardStats.Add(TotalSetStats);
@@ -219,7 +219,7 @@ new Dictionary<string, int>
                 double totalAvgDustValue = 0;
                 foreach (var group in _cards.GroupBy(c => c.Card.Rarity))
                 {
-                    string currentRarity = group.Key;
+                    string currentRarity = group.Key.ToString();
                     int maxCardsAmount = group.Sum(c => c.MaxAmountInCollection);
 
                     int havingNonGolden = group.Sum(c => c.AmountNonGolden);
@@ -244,7 +244,7 @@ new Dictionary<string, int>
                 double totalAvgDustValue = 0;
                 foreach(var group in _cards.GroupBy(c => c.Card.Rarity))
                 {
-                    string currentRarity = group.Key;
+                    string currentRarity = group.Key.ToString();
                     int maxCardsAmount = group.Sum(c => c.MaxAmountInCollection);
 
                     int disenchantingCards = group.Sum(c => Math.Min(c.AmountGolden + c.AmountNonGolden + (c.MaxAmountInCollection - c.DesiredAmount), c.MaxAmountInCollection));
@@ -283,7 +283,7 @@ new Dictionary<string, int>
             double oddsForAllRaritites = 0.0;
             foreach (var group in cards.GroupBy(c => c.Card.Rarity, c => new { card = c, amount = cardsAmount(c) }))
             {
-                double currentProbability = probabilities[group.Key];
+                double currentProbability = probabilities[group.Key.ToString()];
                 int missingCardsAmount = group.Sum(c => Math.Min(1, c.amount));
                 int totalCardsAmount = group.Count();
                 double missingCardsOdds = (double)missingCardsAmount / totalCardsAmount;
@@ -300,7 +300,7 @@ new Dictionary<string, int>
             double totalRequiredDust = 0;
             foreach (var group in _cards.GroupBy(c => c.Card.Rarity))
             {
-                string currentRarity = group.Key;
+                string currentRarity = group.Key.ToString();
                 double missingCards = group.Sum(missingCardsCount);
                 totalRequiredDust += cardsCraftValue[currentRarity] * missingCards;
             }


### PR DESCRIPTION
I'm very sorry for breaking compatibility again!

The relevant commit in HDT:
https://github.com/Epix37/Hearthstone-Deck-Tracker/commit/b6b3a165b607f76be9edfb3dc5e95a07ce0e79c7
