### PR TITLE
Import tool loop needs second "Enter" strike

### DIFF
--- a/Hearthstone Collection Tracker/Internal/Importing/HearthstoneImporter.cs
+++ b/Hearthstone Collection Tracker/Internal/Importing/HearthstoneImporter.cs
@@ -175,8 +175,9 @@ namespace Hearthstone_Collection_Tracker.Internal.Importing
             {
                 SendKeys.SendWait(fixedName);
             }
+            SendKeys.SendWait("{ENTER}");   //Needs a second "Enter" press to reset properly (so search field is blank at query begining)
             SendKeys.SendWait("{ENTER}");
-
+            
             Logger.WriteLine("try to import card: " + card.Name, LOGGER_CATEGORY, 1);
             await Task.Delay(ImportStepDelay * 3);
 


### PR DESCRIPTION
Pressing enter a second time will reset the search field for the next query, so that each name is searched on it's own and not attached to the last search.
