### PR TITLE
Fix occasional null reference exception on Unload

### DIFF
--- a/Hearthstone Collection Tracker/HearthstoneCollectionTrackerPlugin.cs
+++ b/Hearthstone Collection Tracker/HearthstoneCollectionTrackerPlugin.cs
@@ -111,7 +111,10 @@ namespace Hearthstone_Collection_Tracker
                 }
                 _settingsWindow = null;
             }
-            Settings.SaveSettings(PluginDataDir);
+            if (Settings != null)
+            {
+                Settings.SaveSettings(PluginDataDir);
+            }
         }
 
         public void OnButtonPress()


### PR DESCRIPTION
Settings save operation fails when plugin was loaded but never opened.
