### PR TITLE
Remove unnused variables inside catches

### DIFF
--- a/Hearthstone Collection Tracker/Internal/DataUpdaters/BaseUpdaterByVersion.cs
+++ b/Hearthstone Collection Tracker/Internal/DataUpdaters/BaseUpdaterByVersion.cs
@@ -34,7 +34,7 @@ namespace Hearthstone_Collection_Tracker.Internal.DataUpdaters
 
                     return currentVersion < new ModuleVersion(Version);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     return false;
                 }

--- a/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV021.cs
+++ b/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV021.cs
@@ -37,7 +37,7 @@ namespace Hearthstone_Collection_Tracker.Internal.DataUpdaters
                     var settings = Hearthstone_Deck_Tracker.XmlManager<PluginSettings>.Load(configFilePath);
                     return settings.CurrentVersion < new ModuleVersion(_version);
                 }
-                catch(Exception ex)
+                catch(Exception)
                 {
                     return false;
                 }

--- a/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV022.cs
+++ b/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV022.cs
@@ -38,7 +38,7 @@ namespace Hearthstone_Collection_Tracker.Internal.DataUpdaters
                     var settings = Hearthstone_Deck_Tracker.XmlManager<PluginSettings>.Load(configFilePath);
                     return settings.CurrentVersion < new ModuleVersion(_version);
                 }
-                catch(Exception ex)
+                catch(Exception)
                 {
                     return false;
                 }

--- a/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV03.cs
+++ b/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV03.cs
@@ -36,7 +36,7 @@ namespace Hearthstone_Collection_Tracker.Internal.DataUpdaters
                     var settings = Hearthstone_Deck_Tracker.XmlManager<PluginSettings>.Load(configFilePath);
                     return settings.CurrentVersion < new ModuleVersion(_version);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     return false;
                 }

--- a/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV031.cs
+++ b/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV031.cs
@@ -36,7 +36,7 @@ namespace Hearthstone_Collection_Tracker.Internal.DataUpdaters
                     var settings = Hearthstone_Deck_Tracker.XmlManager<PluginSettings>.Load(configFilePath);
                     return settings.CurrentVersion < new ModuleVersion(_version);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     return false;
                 }

--- a/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV032.cs
+++ b/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV032.cs
@@ -36,7 +36,7 @@ namespace Hearthstone_Collection_Tracker.Internal.DataUpdaters
                     var settings = Hearthstone_Deck_Tracker.XmlManager<PluginSettings>.Load(configFilePath);
                     return settings.CurrentVersion < new ModuleVersion(_version);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     return false;
                 }

--- a/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV04.cs
+++ b/Hearthstone Collection Tracker/Internal/DataUpdaters/DataUpdaterV04.cs
@@ -39,7 +39,7 @@ namespace Hearthstone_Collection_Tracker.Internal.DataUpdaters
                     var settings = Hearthstone_Deck_Tracker.XmlManager<PluginSettings>.Load(configFilePath);
                     return settings.CurrentVersion < new ModuleVersion(_version);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
                     return false;
                 }

--- a/Hearthstone Collection Tracker/Internal/Importing/HearthstoneImporter.cs
+++ b/Hearthstone Collection Tracker/Internal/Importing/HearthstoneImporter.cs
@@ -96,7 +96,7 @@ namespace Hearthstone_Collection_Tracker.Internal.Importing
                     }
                 }
             }
-            catch (ImportingException e)
+            catch (ImportingException)
             {
                 ShowHDTOverlay();
                 throw;


### PR DESCRIPTION
It would cause compilation warnings, removing them will make compilation
smoother.
